### PR TITLE
安装脚本通过go env获取GOPATH

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -9,6 +9,10 @@ if [ -d ${install_path} ];then
     install_path=${install_path}-$( date +%Y%m%d%H%M%S )
 fi
 
+if [ -z ${GOPATH} ];then
+    GOPATH=`go env GOPATH`
+fi
+
 build_syncd() {
     go get ${build_repo}
     cd $GOPATH/src/${build_repo}


### PR DESCRIPTION
go环境变量未必会定义在bash环境变量中。
应该在为空时，通过`go env`获取它。