### PR TITLE
emoji 报错解决

### DIFF
--- a/db.go
+++ b/db.go
@@ -49,7 +49,7 @@ func (db *DB) parseConnConfig() string {
     } else {
         connHost = fmt.Sprintf("tcp(%s:%s)", db.cfg.Host, db.cfg.Port)
     }
-    s := fmt.Sprintf("%s:%s@%s/%s?charset=%s&parseTime=True&loc=Local", db.cfg.User, db.cfg.Pass, connHost, db.cfg.DbName, db.cfg.Charset)
+    s := fmt.Sprintf("%s:%s@%s/%s?charset=%s&parseTime=True&loc=Local", db.cfg.User, db.cfg.Pass, connHost, db.cfg.DbName, "utf8mb4")
 
     return s
 }


### PR DESCRIPTION
> In order to fully support UTF-8 encoding, you need to change charset=utf8 to charset=utf8mb4. See this article for a detailed explanation.

我尝试在提交上线单时编写 emoji 字符 `test foo𝌆bar`,报错如下
```
// 前端报错
{"code":1001,"message":"apply submit failed"}
// 后端报错
 mysql query error: Error 1366: Incorrect string value: '\xF0\x9D\x8C\x86ba...' 
```
看到目前代码仅支持 mysql, 索性直接把 utf8mb4 写死了，不知道是否可以。