### PR TITLE
优化上线单管理－编辑上线单

### DIFF
--- a/web/src/views/deploy/ApplyUpdateComponent.js
+++ b/web/src/views/deploy/ApplyUpdateComponent.js
@@ -73,6 +73,7 @@ const UpdateApply = {
                                 { required: true, message: '选择上线版本' },
                             ],
                             validateTrigger: 'blur',
+                            initialValue: this.detail.repo_commit,
                         })(<div></div>)}
                         <div>
                             <a-select
@@ -132,7 +133,7 @@ const UpdateApply = {
                         </a-row>
                         { this.detail.repo_tag != "" ?  (<div>{this.detail.repo_tag}</div>): '' }
                     </a-form-item>
-                ) : ''}
+                ) : <div></div>}
                 <a-form-item
                 {...{ props: formItemLayout }}
                 help={this.nameHelp}

--- a/web/src/views/deploy/Deploy.vue
+++ b/web/src/views/deploy/Deploy.vue
@@ -389,11 +389,11 @@ export default {
                 }
                 this.dialogEditConfirmLoading = true
                 updateApplyApi(values).then(res => {
-                    this.dialogAuditConfirmLoading = false
+                    this.dialogEditConfirmLoading = false
                     this.handleTableChange(this.pagination)
                     this.dialogEditCancel()
                 }).catch(err => {
-                    this.dialogAuditConfirmLoading = false
+                    this.dialogEditConfirmLoading = false
                 })
             })
         },


### PR DESCRIPTION
1. 修复:编辑上线单提交错误后,　loading 不消失
2. 优化:如果只想编辑标题,还需要重新选择上线版本才能提交